### PR TITLE
Run juice even without a stylesheet so <style> tag CSS can be inlined.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -63,18 +63,28 @@ var EmailTemplate = function(templateDirectory, defaults, done) {
     html = ejs.render(html, locals);
     locals.filename = path.join(templatePath, 'text.ejs');
     text = (text) ? ejs.render(text, locals) : '';
-    if (stylesheet) html = juice(html, stylesheet);
-
-    // return a compressed buffer
-    if (isBuffer) {
-      async.map([ new Buffer(html), new Buffer(text) ], zlib[bufferType], function(err, buffers) {
-        if (err) return callback(err)
-        html = buffers[0]
-        text = buffers[1]
-        callback(null, html, text)
-      })
+    if (stylesheet) {
+      html = juice(html, stylesheet);
+      finish();
     } else {
-      callback(null, html, text)
+      juice.juiceContent(html, {url: '.'}, function(err, _html) {
+        html = _html;
+        finish();
+      });
+    }
+
+    function finish() {
+      // return a compressed buffer
+      if (isBuffer) {
+        async.map([ new Buffer(html), new Buffer(text) ], zlib[bufferType], function(err, buffers) {
+          if (err) return callback(err)
+          html = buffers[0]
+          text = buffers[1]
+          callback(null, html, text)
+        })
+      } else {
+        callback(null, html, text)
+      }      
     }
   };
 


### PR DESCRIPTION
I have the same request as https://github.com/niftylettuce/node-email-templates/issues/35.

What I've done here allows me to do something like this:

    <style>
      <% include ../shared-styles.css %>
    </style>

so that multiple email templates share CSS that gets inlined by juice. I implemented this in a weird, lazy way, so I understand you probably won't want to merge it without some cleaning up.

Are you willing to support something like this or come up with a better way to share CSS?