### PR TITLE
npm: Indicate that 0.12.x is a supported engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "url": "https://github.com/niftylettuce/node-email-templates.git"
   },
   "engines": {
-    "node": "0.10.x"
+    "node": "0.10.x",
+    "node": "0.12.x"
   },
   "main": "lib/main.js",
   "scripts": {


### PR DESCRIPTION
Since the project is node 0.12 compatible and has tests running against that engine, we can indicate support in package.json to suppress the warning npm will print out if you install running 0.12