### PR TITLE
Allow passing options to juice

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -74,8 +74,12 @@ var EmailTemplate = function(templateDirectory, defaults, done) {
       text = results[1]
       stylesheet = results[2]
 
+      // Make a copy of the juiceOptions object so we can add the stylesheet.
+      var juiceOptions = (typeof locals.juiceOptions === 'object' ? _.assign({}, locals.juiceOptions) : {})
+      juiceOptions.extraCss = (juiceOptions.extraCss || "") + stylesheet
+
       // Inject available styles into HTML.
-      html = (stylesheet) ? juice(html, {extraCss: stylesheet}) : html
+      html = (stylesheet) ? juice(html, juiceOptions) : html
 
       // Return a compressed buffer if needed.
       if (isBuffer) {

--- a/test/integration.js
+++ b/test/integration.js
@@ -81,6 +81,27 @@ describe('Email templates', function() {
       })
     })
 
+    it('html with style element and juiceOptions', function(done) {
+      var html = '<style> h4 { color: red; }</style><h4><%= item%></h4>'
+        , css  = 'h4 { color: blue; }';
+      fs.writeFileSync(path.join(templateDir, templateName, 'html.ejs'), html)
+      fs.writeFileSync(path.join(templateDir, templateName, 'style.ejs'), css)
+
+      var defaults = {
+        juiceOptions: { removeStyleTags: false }
+      }
+
+      emailTemplates(templateDir, defaults, function(err, template) {
+        template(templateName, { item: 'test' }, function(err, html, text) {
+          expect(err).to.be.null
+          expect(text).to.be.false
+          expect(html).to.equal(
+            '<style> h4 { color: red; }</style><h4 style=\"color: blue;\">test</h4>')
+          done()
+        });
+      });
+    });
+
     it('html with inline CSS(ejs) and text file', function(done) {
       var html = '<h4><%= item%></h4>'
         , text = '<%= item%>'


### PR DESCRIPTION
You really don't like semicolons, do you? :-)

Anyway, we'd like to use some fonts and media queries in our template. This patch allows us to pass the right options to juice. Let me know what you think!