### PR TITLE
Add support for node-sass >= 3.0.0

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -97,7 +97,7 @@ npm install -S [ejs|jade|swig|handlebars|emblem|dust-linkedin]
     - `less@^1.7.0`
     - `stylus@^^0.45.1`
     - `styl@^0.2.7`
-    - `node-sass@^0.9.3`
+    - `node-sass@^3.1.1`
 
     ```bash
     npm install -S <engine>

--- a/lib/templateManager.js
+++ b/lib/templateManager.js
@@ -78,15 +78,20 @@ function renderStyl(source, locals, cb) {
 function renderSass(source, locals, cb) {
   var sass = require('node-sass')
 
-  // Result handlers required by sass.
+  // Result handlers required by node-sass < 3.0.0.
   function errorHandler(err) { cb(err) }
   function successHandler(data) { cb(null, data.css)}
+  locals.success = successHandler
+  locals.error = errorHandler
 
   locals.data = source
   locals.includePaths = [locals.templatePath];
-  locals.success = successHandler
-  locals.error = errorHandler
-  sass.render(locals)
+
+  sass.render(locals, function(err, result) {
+    if (err) { return cb(err); }
+
+    cb(null, result.css.toString());
+  });
 }
 
 // Default wrapper for handling standard CSS and empty source.

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "less": "^1.7.0",
     "stylus": "^0.45.1",
     "styl": "^0.2.7",
-    "node-sass": "^2.0.1",
+    "node-sass": "^3.1.1",
     "sinon": "^1.10.2",
     "sinon-chai": "^2.7.0",
     "istanbul": "^0.3.2"


### PR DESCRIPTION
This adds support for node-sass 3.0.0 while maintaining previous version support.