### PR TITLE
Add ability to pass in options to node-sass.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,14 @@ new EmailTemplate(templateDir, {juiceOptions: {
 
 You can check all the options in [juice's documentation](https://github.com/automattic/juice#options)
 
+You can add includePaths for [sass][sass] using sassOptions.
+
+```javascript
+new EmailTemplate(templateDir, {sassOptions: {
+  includePaths: ['~/someproject/sass']
+}})
+```
+
 ## Examples
 
 ### Basic

--- a/src/email-template.js
+++ b/src/email-template.js
@@ -3,6 +3,7 @@ import Debug from 'debug'
 import {basename} from 'path'
 import juice from 'juice'
 import isFunction from 'lodash/isFunction'
+import assign from 'lodash/assign'
 import {ensureDirectory, readContents, renderFile} from './util'
 
 const debug = Debug('email-templates:email-template')
@@ -119,6 +120,10 @@ export default class EmailTemplate {
 
       // no style
       if (!this.files.style) return resolve(null)
+
+      if (this.options.sassOptions) {
+        locals = assign({}, locals, this.options.sassOptions)
+      }
 
       debug('Rendering stylesheet')
       renderFile(this.files.style, locals)

--- a/src/template-manager.js
+++ b/src/template-manager.js
@@ -98,7 +98,12 @@ function renderSass (source, locals) {
   const sass = require('node-sass')
 
   locals.data = source
-  locals.includePaths = [locals.templatePath]
+
+  if (locals.includePaths) {
+    locals.includePaths = locals.includePaths.concat([locals.templatePath])
+  } else {
+    locals.includePaths = [locals.templatePath]
+  }
 
   return new P(function (done, reject) {
     sass.render(locals, function (err, data) {


### PR DESCRIPTION
For my project I need to include an external sass project via npm. Because of limitations I was unable to import this package. This allows us to do this.