### PR TITLE
Fix unhandled style exceptions

### DIFF
--- a/src/email-template.js
+++ b/src/email-template.js
@@ -126,11 +126,11 @@ export default class EmailTemplate {
       }
 
       debug('Rendering stylesheet')
-      renderFile(this.files.style, locals)
+      resolve(renderFile(this.files.style, locals))
       .then((style) => {
         this.style = style
         debug('Finished rendering stylesheet')
-        resolve(style)
+        return style
       })
     })
   }

--- a/test/testEmailTemplate.js
+++ b/test/testEmailTemplate.js
@@ -153,5 +153,24 @@ describe('EmailTemplate', function () {
         .catch(done)
       })
     })
+
+    it('should reject if the style can’t be compiled', function (done) {
+      var html = '<h4><%= item %></h4>'
+      var css = 'h4 { <%=color: blue; }'
+
+      fs.writeFileSync(path.join(templatePath, 'html.ejs'), html)
+      fs.writeFileSync(path.join(templatePath, 'style.ejs'), css)
+
+      var et = new EmailTemplate(templatePath, {
+        juiceOptions: { removeStyleTags: false }
+      })
+
+      et.render({ item: 'test' })
+      .then(function (results) {
+        done(new Error('Should not be reached'))
+      }, function () {
+        done()
+      })
+    })
   })
 })


### PR DESCRIPTION
`_renderStyle` did not handle rendering exceptions properly because it forgot to handle or forward rejectios of `renderFile`’s promise.