### PR TITLE
allow html files to end with .html ext (use default renderer)

### DIFF
--- a/src/template-manager.js
+++ b/src/template-manager.js
@@ -10,6 +10,7 @@ import P from 'bluebird'
 
 var engineMap = {
   // HTML Template engines
+  'html': renderDefault,
   'hbs': cons.handlebars.render,
   'emblem': renderEmblem,
   // CSS pre-processors


### PR DESCRIPTION
Hi!

I had this need when using "html.html" file as a template was throwing a `TypeError` "fn is not a function", which was popped here: https://github.com/VinceOPS/node-email-templates/blob/f1c97282bf2eb82c38ef8bab8f66f1ca63ef5dae/src/template-manager.js#L48, because no entry was available for `'html'` in `engineMap`.

Thanks for your work!