### PR TITLE
added option for disabling juice (fixes #139)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Install `email-templates` and the engines you wish to use by adding them to your
 ```bash
 npm install --save email-templates
 # See https://www.npmjs.com/package/consolidate for a full list of available template engines
-npm install -S [ejs|jade|nunjucks|handlebars|emblem|dust-linkedin] 
+npm install -S [ejs|jade|nunjucks|handlebars|emblem|dust-linkedin]
 ```
 
 
@@ -84,7 +84,7 @@ npm install -S [ejs|jade|nunjucks|handlebars|emblem|dust-linkedin]
     - `stylus@^0.51.0`
     - `styl@^0.2.0`
     - `node-sass@^3.0.0`
-    
+
     - See https://www.npmjs.com/package/consolidate for a full list
 
     ```bash
@@ -142,6 +142,12 @@ new EmailTemplate(templateDir, {juiceOptions: {
 ```
 
 You can check all the options in [juice's documentation](https://github.com/automattic/juice#options)
+
+If you wish to disable juice, you can pass `disableJuice` as an option:
+
+```javascript
+new EmailTemplate(templateDir, { disableJuice: true })
+```
 
 You can add includePaths for [sass][sass] using sassOptions.
 

--- a/src/email-template.js
+++ b/src/email-template.js
@@ -100,6 +100,7 @@ export default class EmailTemplate {
     .then((results) => {
       let [html, style] = results
       if (!style) return html
+      if (this.options.disableJuice) return html
       if (this.options.juiceOptions) {
         debug('Using juice options ', this.options.juiceOptions)
       }

--- a/test/testEmailTemplate.js
+++ b/test/testEmailTemplate.js
@@ -120,6 +120,26 @@ describe('EmailTemplate', function () {
       .catch(done)
     })
 
+    it('skip inlining if disableJuice is set to true', function (done) {
+      var html = '<style> h4 { color: red; }</style><h4><%= item %></h4>'
+      var css = 'h4 { color: blue; }'
+
+      fs.writeFileSync(path.join(templatePath, 'html.ejs'), html)
+      fs.writeFileSync(path.join(templatePath, 'style.ejs'), css)
+
+      var et = new EmailTemplate(templatePath, {
+        disableJuice: true
+      })
+
+      et.render({ item: 'test' })
+      .then(function (results) {
+        expect(results.html).to.equal(
+          '<style> h4 { color: red; }</style><h4>test</h4>')
+        done()
+      })
+      .catch(done)
+    })
+
     it('render calls should not mutate view data', function (done) {
       var html = '<style> h4 { color: red; }</style><h4><%= item %></h4>'
       var css = 'h4 { color: blue; }'


### PR DESCRIPTION
First, thanks for the great library! It's been immensely helpful.

This PR adds an option to allow for disabling Juice inlining.

#139 provides one reason for allowing this. For me, I'm using Foundation for Emails, which comes with a complete workflow for producing emails, including inlining. I prefer to inline the styles beforehand so it's only done once.